### PR TITLE
feat: add strided iterator and step functionality to vector class

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v2
+    #  uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
        cmake --build --preset linux-release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v1
+    #  uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
        cmake --build --preset linux-release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+      with:
+        submodules: true
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/include/dicek/linalg/vector.hpp
+++ b/include/dicek/linalg/vector.hpp
@@ -22,11 +22,15 @@ SOFTWARE.
 #ifndef UUID_6F484ACB_9C23_4013_A905_B5DAC701113A
 #define UUID_6F484ACB_9C23_4013_A905_B5DAC701113A
 
+#include <algorithm>
 #include <cstddef>
 #include <dicek/scalar_traits.hpp>
 #include <initializer_list>
+#include <iterator>
 #include <memory_resource>
 #include <optional>
+#include <stdexcept>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -36,15 +40,137 @@ class vector {
  public:
   using scalar_type = typename scalar_traits::scalar_type;
 
+  template<typename pointer_type>
+  class strided_iterator {
+   public:
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type        = scalar_type;
+    using difference_type   = std::ptrdiff_t;
+    using pointer           = pointer_type;
+    using reference         = std::conditional_t<std::is_const_v<std::remove_pointer_t<pointer_type>>, const value_type&, value_type&>;
+
+    strided_iterator() : base_(nullptr), index_(0), step_(1) {}
+    strided_iterator(pointer base, difference_type index, difference_type step) : base_(base), index_(index), step_(step) {}
+
+    template<typename other_pointer_type, typename = std::enable_if_t<std::is_convertible_v<other_pointer_type, pointer_type>>>
+    strided_iterator(const strided_iterator<other_pointer_type>& rhs) : base_(rhs.base_), index_(rhs.index_), step_(rhs.step_) {}
+
+    reference operator*() const {
+      return *(base_ + index_ * step_);
+    }
+
+    pointer operator->() const {
+      return base_ + index_ * step_;
+    }
+
+    strided_iterator& operator++() {
+      ++index_;
+      return *this;
+    }
+
+    strided_iterator operator++(int) {
+      strided_iterator tmp(*this);
+      ++*this;
+      return tmp;
+    }
+
+    strided_iterator& operator--() {
+      --index_;
+      return *this;
+    }
+
+    strided_iterator operator--(int) {
+      strided_iterator tmp(*this);
+      --*this;
+      return tmp;
+    }
+
+    strided_iterator& operator+=(difference_type n) {
+      index_ += n;
+      return *this;
+    }
+
+    strided_iterator& operator-=(difference_type n) {
+      index_ -= n;
+      return *this;
+    }
+
+    strided_iterator operator+(difference_type n) const {
+      strided_iterator tmp(*this);
+      tmp += n;
+      return tmp;
+    }
+
+    friend strided_iterator operator+(difference_type n, strided_iterator rhs) {
+      rhs += n;
+      return rhs;
+    }
+
+    strided_iterator operator-(difference_type n) const {
+      strided_iterator tmp(*this);
+      tmp -= n;
+      return tmp;
+    }
+
+    template<typename other_pointer_type>
+    difference_type operator-(const strided_iterator<other_pointer_type>& rhs) const {
+      return index_ - rhs.index_;
+    }
+
+    reference operator[](difference_type n) const {
+      return *(*this + n);
+    }
+
+    template<typename other_pointer_type>
+    bool operator==(const strided_iterator<other_pointer_type>& rhs) const {
+      return base_ == rhs.base_ && index_ == rhs.index_ && step_ == rhs.step_;
+    }
+
+    template<typename other_pointer_type>
+    bool operator!=(const strided_iterator<other_pointer_type>& rhs) const {
+      return !(*this == rhs);
+    }
+
+    template<typename other_pointer_type>
+    bool operator<(const strided_iterator<other_pointer_type>& rhs) const {
+      return index_ < rhs.index_;
+    }
+
+    template<typename other_pointer_type>
+    bool operator<=(const strided_iterator<other_pointer_type>& rhs) const {
+      return index_ <= rhs.index_;
+    }
+
+    template<typename other_pointer_type>
+    bool operator>(const strided_iterator<other_pointer_type>& rhs) const {
+      return index_ > rhs.index_;
+    }
+
+    template<typename other_pointer_type>
+    bool operator>=(const strided_iterator<other_pointer_type>& rhs) const {
+      return index_ >= rhs.index_;
+    }
+
+   private:
+    template<typename>
+    friend class strided_iterator;
+
+    pointer base_;
+    difference_type index_;
+    difference_type step_;
+  };
+
   /* constructor (1) */
-  vector() : length_(0), allocator_(), ref_count_(nullptr), elm_(nullptr){};
+  vector() : length_(0), allocator_(), ref_count_(nullptr), elm_(nullptr), step_(1) {};
   /* constructor (2) */
-  vector(std::size_t length, std::pmr::memory_resource* alloc = std::pmr::get_default_resource()) : length_(length), allocator_(alloc), ref_count_(nullptr), elm_(nullptr) {
+  vector(std::size_t length, std::pmr::memory_resource* alloc = std::pmr::get_default_resource()) : length_(length), allocator_(alloc), ref_count_(nullptr), elm_(nullptr), step_(1) {
     using scalar_type_allocator_type                 = typename std::allocator_traits<std::pmr::polymorphic_allocator<std::byte>>::template rebind_alloc<scalar_type>;
     using scalar_type_allocator_traits               = std::allocator_traits<scalar_type_allocator_type>;
     scalar_type_allocator_type scalar_type_allocator = allocator_;
     elm_                                             = scalar_type_allocator_traits::allocate(scalar_type_allocator, length_);
-    scalar_type_allocator_traits::construct(scalar_type_allocator, elm_);
+    for (std::size_t i = 0; i < length_; ++i) {
+      scalar_type_allocator_traits::construct(scalar_type_allocator, elm_ + i);
+    }
 
     using size_t_allocator_type            = typename std::allocator_traits<std::pmr::polymorphic_allocator<std::byte>>::template rebind_alloc<size_t>;
     using size_t_allocator_traits          = std::allocator_traits<size_t_allocator_type>;
@@ -54,19 +180,24 @@ class vector {
     ++*ref_count_;
   }
   /* constructor (3) */
-  vector(scalar_type* buf, std::size_t length) : length_(length), allocator_(std::pmr::null_memory_resource()), ref_count_(nullptr), elm_(buf) {}
+  vector(scalar_type* buf, std::size_t length, int step = 1) : length_(length), allocator_(std::pmr::null_memory_resource()), ref_count_(nullptr), elm_(buf), step_(step) {
+    if (step == 0) {
+      throw std::invalid_argument("vector::vector: step must not be zero");
+    }
+  }
   /* constructor (4) */
   vector(std::initializer_list<scalar_type> ini, std::pmr::memory_resource* alloc = std::pmr::get_default_resource()) : vector(ini.size(), alloc) {
     std::copy(std::begin(ini), std::end(ini), std::begin(*this));
   }
   /* copy constructor */
-  vector(const vector& rhs) : length_(rhs.length_), allocator_(rhs.allocator_), ref_count_(rhs.ref_count_), elm_(rhs.elm_) {
+  vector(const vector& rhs) : length_(rhs.length_), allocator_(rhs.allocator_), ref_count_(rhs.ref_count_), elm_(rhs.elm_), step_(rhs.step_) {
     if (ref_count_ != nullptr) {
       ++*ref_count_;
     }
   }
   /* move constructor */
-  vector(vector&& rhs) noexcept : length_(std::exchange(rhs.length_, 0)), allocator_(std::move(rhs.allocator_)), ref_count_(std::exchange(rhs.ref_count_, nullptr)), elm_(std::exchange(rhs.elm_, nullptr)) {}
+  vector(vector&& rhs) noexcept
+      : length_(std::exchange(rhs.length_, 0)), allocator_(std::exchange(rhs.allocator_, nullptr)), ref_count_(std::exchange(rhs.ref_count_, nullptr)), elm_(std::exchange(rhs.elm_, nullptr)), step_(std::exchange(rhs.step_, 1)) {}
 
   /* destructor */
   ~vector() noexcept {
@@ -77,12 +208,14 @@ class vector {
         need_free = false;
       }
     }
-    if (need_free && allocator_ != nullptr) {
+    if (need_free && ref_count_ != nullptr && allocator_ != nullptr) {
       using scalar_type_allocator_type                 = typename std::allocator_traits<std::pmr::polymorphic_allocator<std::byte>>::template rebind_alloc<scalar_type>;
       using scalar_type_allocator_traits               = std::allocator_traits<scalar_type_allocator_type>;
       scalar_type_allocator_type scalar_type_allocator = allocator_;
       if (elm_ != nullptr) {
-        scalar_type_allocator_traits::destroy(scalar_type_allocator, elm_);
+        for (std::size_t i = 0; i < length_; ++i) {
+          scalar_type_allocator_traits::destroy(scalar_type_allocator, elm_ + i);
+        }
         scalar_type_allocator_traits::deallocate(scalar_type_allocator, elm_, length_);
       }
 
@@ -105,39 +238,44 @@ class vector {
 
   vector& operator=(vector&& rhs) noexcept {
     if (this != &rhs) {
-      length_    = std::exchange(rhs.length_, 0);
-      allocator_ = std::exchange(rhs.allocator_, nullptr);
-      ref_count_ = std::exchange(rhs.ref_count_, nullptr);
-      elm_       = std::exchange(rhs.elm_, nullptr);
+      vector(std::move(rhs)).swap(*this);
     }
     return *this;
   }
 
   void swap(vector& rhs) noexcept {
     using std::swap;
-    swap(*this, rhs);
+    swap(length_, rhs.length_);
+    swap(allocator_, rhs.allocator_);
+    swap(ref_count_, rhs.ref_count_);
+    swap(elm_, rhs.elm_);
+    swap(step_, rhs.step_);
   }
 
-  using iterator       = scalar_type*;
-  using const_iterator = const scalar_type*;
+  friend void swap(vector& lhs, vector& rhs) noexcept {
+    lhs.swap(rhs);
+  }
+
+  using iterator       = strided_iterator<scalar_type*>;
+  using const_iterator = strided_iterator<const scalar_type*>;
 
   const_iterator begin() const {
-    return elm_;
+    return const_iterator(elm_, 0, step_);
   }
   const_iterator cbegin() const {
     return begin();
   }
   iterator begin() {
-    return const_cast<iterator>(this->cbegin());
+    return iterator(elm_, 0, step_);
   }
   const_iterator end() const {
-    return elm_ + length_;
+    return const_iterator(elm_, static_cast<std::ptrdiff_t>(length_), step_);
   }
   const_iterator cend() const {
     return end();
   }
   iterator end() {
-    return const_cast<iterator>(this->cend());
+    return iterator(elm_, static_cast<std::ptrdiff_t>(length_), step_);
   }
 
   std::size_t size() const {
@@ -145,7 +283,7 @@ class vector {
   }
 
   const scalar_type& operator[](std::size_t idx) const {
-    return elm_[idx];
+    return *(elm_ + static_cast<std::ptrdiff_t>(idx) * step_);
   }
   const scalar_type& at(size_t idx) const {
     if (idx >= length_) {
@@ -196,6 +334,7 @@ class vector {
   std::pmr::memory_resource* allocator_;
   std::size_t* ref_count_;
   scalar_type* elm_;
+  std::ptrdiff_t step_;
 };
 }  // namespace dicek::math::linalg
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,8 +21,8 @@ macro(package_add_test TESTNAME)
   # see https://cmake.org/cmake/help/v3.10/module/GoogleTest.html for more options to pass to it
   gtest_discover_tests(${TESTNAME}
     # set a working directory so your project root so that you can find test data via paths relative to the project root
-    WORKING_DIRECTORY ${PROJECT_DIR}
-    PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_DIR}"
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
   )
   set_target_properties(${TESTNAME} PROPERTIES
     FOLDER tests

--- a/test/vectorTest.cpp
+++ b/test/vectorTest.cpp
@@ -112,6 +112,63 @@ TEST(vectorTest, external_buffer_constructor) {
   EXPECT_FALSE(vec.ref_count());
 }
 
+TEST(vectorTest, external_buffer_constructor_with_step) {
+  std::array<double, 9> buf = {1, -1, 2, -1, 3, -1, 4, -1, 5};
+  constexpr auto N          = 5;
+
+  using type = double;
+  vector<type> vec(buf.data(), N, 2);
+
+  const auto& cvec = vec;
+  for (size_t i = 0; i < vec.size(); ++i) {
+    EXPECT_EQ(static_cast<type>(i + 1), cvec.at(i));
+  }
+
+  vec.at(1) = 20;
+  EXPECT_EQ(20, buf.at(2));
+  EXPECT_EQ(-1, buf.at(1));
+
+  std::array<double, N> copied = {};
+  std::copy(vec.begin(), vec.end(), copied.begin());
+  for (size_t i = 0; i < copied.size(); ++i) {
+    EXPECT_EQ(cvec.at(i), copied.at(i));
+  }
+
+  EXPECT_EQ(buf.data(), cvec.data());
+  EXPECT_EQ(buf.data(), vec.data());
+  EXPECT_FALSE(vec.ref_count());
+}
+
+TEST(vectorTest, external_buffer_constructor_with_negative_step) {
+  std::array<double, 5> buf = {1, 2, 3, 4, 5};
+  constexpr auto N          = buf.size();
+
+  using type = double;
+  vector<type> vec(buf.data() + buf.size() - 1, N, -1);
+
+  const auto& cvec = vec;
+  for (size_t i = 0; i < vec.size(); ++i) {
+    EXPECT_EQ(static_cast<type>(N - i), cvec.at(i));
+  }
+
+  vec.at(2) = 30;
+  EXPECT_EQ(30, buf.at(2));
+
+  auto bite = vec.begin();
+  auto eite = vec.end();
+  EXPECT_EQ(vec.size(), std::distance(bite, eite));
+
+  EXPECT_EQ(buf.data() + buf.size() - 1, cvec.data());
+  EXPECT_FALSE(vec.ref_count());
+}
+
+TEST(vectorTest, external_buffer_constructor_rejects_zero_step) {
+  std::array<double, 5> buf = {1, 2, 3, 4, 5};
+
+  using type = double;
+  EXPECT_THROW(vector<type>(buf.data(), buf.size(), 0), std::invalid_argument);
+}
+
 TEST(vectorTest, copy_constructor) {
   using type = float;
   vector<type> vec(3);


### PR DESCRIPTION
- Implemented a strided iterator for the vector class to allow iteration with a specified step.
- Updated constructors to accept a step parameter, ensuring it is validated to be non-zero.
- Modified memory management in the destructor to handle the new step functionality.
- Added tests for the new external buffer constructor with step, including validation for negative and zero steps.

Fix #9 